### PR TITLE
change Updater url

### DIFF
--- a/Assembly-CSharp/WindowsUpdater.cs
+++ b/Assembly-CSharp/WindowsUpdater.cs
@@ -22,9 +22,9 @@ internal class WindowsUpdater
 
 	private static string gamepath = Directory.GetCurrentDirectory();
 
-	private static string url_latest = "https://raw.githubusercontent.com/HaZardousss/UberUpdates/master/Entry.txt";
+	private static string url_latest = "http://client-steam.uberstrike.com/Entry.txt";
 
-	private static string url_auth = "https://raw.githubusercontent.com/HaZardousss/UberUpdates/master/Auth";
+	private static string url_auth = "http://client-steam.uberstrike.com/Auth";
 
 	private static int currentdownloadcount = 0;
 


### PR DESCRIPTION
Github requires TLS, which the old Unity version does not support out of the box.
Moving to my own content webservice to host the files for Update.